### PR TITLE
add InterfaceAddrsByInterface function

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -20,3 +20,9 @@ func Interfaces() ([]net.Interface, error) {
 func InterfaceAddrs() ([]net.Addr, error) {
 	return net.InterfaceAddrs()
 }
+
+// InterfaceAddrsByInterface returns a list of the system's unicast 
+// interface addresses by specific interface.
+func InterfaceAddrsByInterface(ifi *net.Interface) ([]net.Addr, error) {
+	return ifi.Addrs()
+}

--- a/interface_android.go
+++ b/interface_android.go
@@ -38,6 +38,16 @@ func InterfaceAddrs() ([]net.Addr, error) {
 	return ifat, err
 }
 
+// InterfaceAddrsByInterface returns a list of the system's unicast 
+// interface addresses by specific interface.
+func InterfaceAddrsByInterface(ifi *net.Interface) ([]net.Addr, error) {
+	ifat, err := interfaceAddrTable(ifi)
+	if err != nil {
+		err = &net.OpError{Op: "route", Net: "ip+net", Source: nil, Addr: nil, Err: err}
+	}
+	return ifat, err
+}
+
 // If the ifindex is zero, interfaceTable returns mappings of all
 // network interfaces. Otherwise it returns a mapping of a specific
 // interface.


### PR DESCRIPTION
Thanks for your library. That saved me :)

In my case I need to call ```````interface.Addrs()` but it also give 'permission denied' on android. I investigated your realization and saw that implemented, but in private function.

I added the public function InterfaceAddrsByInterface for get addresses from specific interface.
Please check it.
