### PR TITLE
Fix go/issues/68082 for golang.org/x/net subproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ The specific fix logic includes:
 Removing the `Bind()` operation on `Netlink` sockets in the `NetlinkRIB()` function.
 Using `ioctl` based on the Index number returned by `RTM_GETADDR` to retrieve the network card's name, MTU, and flags.
 
-
-
-
+There are two implementations of the `net` package: one from the [Go standard library](https://pkg.go.dev/net) and another from the [golang.org/x/net](https://pkg.go.dev/golang.org/x/net) module. Both of these implementations have the same issues in the Android environment. The `anet` package should be compatible with both of them.
 
 ## Test Code
 ### net.Interface()

--- a/interface_android.go
+++ b/interface_android.go
@@ -38,6 +38,7 @@ func Interfaces() ([]net.Interface, error) {
 	}
 	if len(ift) != 0 {
 		zoneCache.update(ift, false)
+		zoneCacheX.update(ift, false)
 	}
 	return ift, nil
 }
@@ -94,6 +95,7 @@ func InterfaceByName(name string) (*net.Interface, error) {
 	}
 	if len(ift) != 0 {
 		zoneCache.update(ift, false)
+		zoneCacheX.update(ift, false)
 	}
 	for _, ifi := range ift {
 		if name == ifi.Name {
@@ -143,6 +145,9 @@ type ipv6ZoneCache struct {
 
 //go:linkname zoneCache net.zoneCache
 var zoneCache ipv6ZoneCache
+
+//go:linkname zoneCacheX golang.org/x/net/internal/socket.zoneCache
+var zoneCacheX ipv6ZoneCache
 
 // update refreshes the network interface information if the cache was last
 // updated more than 1 minute ago, or if force is set. It reports whether the


### PR DESCRIPTION
I was trying to resolve the multicast functionality issue in https://github.com/yggdrasil-network/yggdrasil-go/issues/1149, and I decided to try using the `anet` library as a first step. It did help me with https://github.com/golang/go/issues/40569, but unfortunately, it didn't help with https://github.com/golang/go/issues/68082.
I tried to dig dipper, and discovered that it's because `yggdrasil-go` uses the implementation of the net package provided by https://pkg.go.dev/golang.org/x/net instead of the core Go implementation (https://github.com/yggdrasil-network/yggdrasil-go/blob/4fbdeb4e3fd77dfc2bef8f9784bf14213d5461e4/go.mod#L17). And `golang.org/x/net` has different linkage name for `zoneCache` [symbol](https://cs.opensource.google/go/x/net/+/master:internal/socket/sys_posix.go;l=119?q=zoneCache&ss=go%2Fx%2Fnet).

I'm not sure if it's worthwhile to support `golang.org/x/net` in the `anet` package, but it may be helpful for some people.