### PR TITLE
Always update network interfaces information in cache

### DIFF
--- a/interface_android.go
+++ b/interface_android.go
@@ -37,8 +37,8 @@ func Interfaces() ([]net.Interface, error) {
 		return nil, &net.OpError{Op: "route", Net: "ip+net", Source: nil, Addr: nil, Err: err}
 	}
 	if len(ift) != 0 {
-		zoneCache.update(ift, false)
-		zoneCacheX.update(ift, false)
+		zoneCache.update(ift, true)
+		zoneCacheX.update(ift, true)
 	}
 	return ift, nil
 }
@@ -94,8 +94,8 @@ func InterfaceByName(name string) (*net.Interface, error) {
 		return nil, &net.OpError{Op: "route", Net: "ip+net", Source: nil, Addr: nil, Err: err}
 	}
 	if len(ift) != 0 {
-		zoneCache.update(ift, false)
-		zoneCacheX.update(ift, false)
+		zoneCache.update(ift, true)
+		zoneCacheX.update(ift, true)
 	}
 	for _, ifi := range ift {
 		if name == ifi.Name {


### PR DESCRIPTION
`anet.Interfaces` and `net.Interfaces` use the same `zoneCache` underneath (and the same `lastFetched`). But because `net.Interfaces` is currently not fully functional on Android, it always tries to clear the cache and update the `lastFetched` timestamp. In certain situations, this may prevent `anet.Interfaces` from populating the cache at all.

Example pseudocode:
```go
  for {
    _, _ = net.Listen(...) // clears zoneCache, updates the timestamp
    _, _ = anet.Interfaces() // doesn't update the cache because it's up to date
  }
```

The `zoneCache` is used to reduce the cost of resolving IPv6 addressing scope zones. Because all expensive operations have already been performed in `anet.Interfaces`, there is no reason not to update the cache (even if it has recent timestamp).