### PR TITLE
Detect Android version automatically

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -27,4 +27,5 @@ func InterfaceAddrsByInterface(ifi *net.Interface) ([]net.Addr, error) {
 	return ifi.Addrs()
 }
 
+// Deprecated: Android version is detected automatically.
 func SetAndroidVersion(version uint) {}

--- a/interface_android.go
+++ b/interface_android.go
@@ -1,5 +1,8 @@
 package anet
 
+// #include <android/api-level.h>
+import "C"
+
 import (
 	"bytes"
 	"errors"
@@ -12,11 +15,10 @@ import (
 )
 
 const (
-	android11 = 11
+	android11ApiLevel = 30
 )
 
 var (
-	androidVersion              uint
 	errInvalidInterface         = errors.New("invalid network interface")
 	errInvalidInterfaceIndex    = errors.New("invalid network interface index")
 	errInvalidInterfaceName     = errors.New("invalid network interface name")
@@ -28,7 +30,7 @@ type ifReq [40]byte
 
 // Interfaces returns a list of the system's network interfaces.
 func Interfaces() ([]net.Interface, error) {
-	if androidVersion < android11 {
+	if androidApiLevel() < android11ApiLevel {
 		return net.Interfaces()
 	}
 
@@ -49,7 +51,7 @@ func Interfaces() ([]net.Interface, error) {
 // The returned list does not identify the associated interface; use
 // Interfaces and Interface.Addrs for more detail.
 func InterfaceAddrs() ([]net.Addr, error) {
-	if androidVersion < android11 {
+	if androidApiLevel() < android11ApiLevel {
 		return net.InterfaceAddrs()
 	}
 
@@ -66,7 +68,7 @@ func InterfaceAddrs() ([]net.Addr, error) {
 // sharing the logical data link; for more precision use
 // InterfaceByName.
 func InterfaceByIndex(index int) (*net.Interface, error) {
-	if androidVersion < android11 {
+	if androidApiLevel() < android11ApiLevel {
 		return net.InterfaceByIndex(index)
 	}
 
@@ -112,7 +114,7 @@ func InterfaceAddrsByInterface(ifi *net.Interface) ([]net.Addr, error) {
 		return nil, &net.OpError{Op: "route", Net: "ip+net", Source: nil, Addr: nil, Err: errInvalidInterface}
 	}
 
-	if androidVersion < android11 {
+	if androidApiLevel() < android11ApiLevel {
 		return ifi.Addrs()
 	}
 
@@ -121,13 +123,6 @@ func InterfaceAddrsByInterface(ifi *net.Interface) ([]net.Addr, error) {
 		err = &net.OpError{Op: "route", Net: "ip+net", Source: nil, Addr: nil, Err: err}
 	}
 	return ifat, err
-}
-
-// SetAndroidVersion set the Android environment in which the program runs.
-// The Android system version number can be obtained through
-// `android.os.Build.VERSION.RELEASE` of the Android framework.
-func SetAndroidVersion(version uint) {
-	androidVersion = version
 }
 
 // An ipv6ZoneCache represents a cache holding partial network
@@ -422,3 +417,18 @@ func nameToFlags(name string) (net.Flags, error) {
 
 	return linkFlags(*(*uint32)(unsafe.Pointer(&ifr[syscall.IFNAMSIZ]))), nil
 }
+
+// Returns the API level of the device we're actually running on, or -1 on failure.
+// The returned value is equivalent to the Java Build.VERSION.SDK_INT API.
+var androidApiLevel = func() func() int {
+	var apiLevel int
+	var once sync.Once
+
+	return func() int {
+		once.Do(func() {
+			apiLevel = int(C.android_get_device_api_level())
+		})
+
+		return apiLevel
+	}
+}()


### PR DESCRIPTION
[int android_get_application_target_sdk_version()](https://developer.android.com/ndk/reference/group/apilevels#android_get_application_target_sdk_version)

```c
/**
 * Names the Android 11 (aka "R" or "Red Velvet Cake") API level (30), for
 * comparison against `__ANDROID_API__`.
 */
#define __ANDROID_API_R__ 30
```